### PR TITLE
Refactor components to use shadcn ui

### DIFF
--- a/schiessmeister-client/src/components/ui/input.tsx
+++ b/schiessmeister-client/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+Input.displayName = "Input"
+
+export { Input }

--- a/schiessmeister-client/src/components/ui/label.tsx
+++ b/schiessmeister-client/src/components/ui/label.tsx
@@ -1,0 +1,15 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const Label = React.forwardRef<React.ElementRef<"label">, React.ComponentPropsWithoutRef<"label">>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn("text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70", className)}
+      {...props}
+    />
+  )
+)
+Label.displayName = "Label"
+
+export { Label }

--- a/schiessmeister-client/src/components/ui/select.tsx
+++ b/schiessmeister-client/src/components/ui/select.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {}
+
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(({ className, ...props }, ref) => (
+  <select
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    {...props}
+  />
+))
+Select.displayName = "Select"
+
+export { Select }

--- a/schiessmeister-client/src/pages/CompetitionOverview.jsx
+++ b/schiessmeister-client/src/pages/CompetitionOverview.jsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { getCompetition, deleteCompetition } from '../api/apiClient';
 import { useAuth } from '../context/AuthContext';
 import '../styles/CompetitionOverview.css';
+import { Button } from '@/components/ui/button';
 
 const CompetitionOverview = () => {
 	const { id } = useParams();
@@ -61,9 +62,9 @@ const CompetitionOverview = () => {
 				{participants.map((participation) => (
 					<div key={participation.id} className="participant-item">
 						<span className="participant-name">{participation.shooter.name}</span>
-						<button className="button button--tertiary results-btn" onClick={() => navigate(`/results/${id}/${participation.id}`)}>
-							Ergebnisse
-						</button>
+                                                <Button variant="outline" onClick={() => navigate(`/results/${id}/${participation.id}`)}>
+                                                        Ergebnisse
+                                                </Button>
 					</div>
 				))}
 				{participants.length === 0 && <p>Keine {title}.</p>}
@@ -85,21 +86,21 @@ const CompetitionOverview = () => {
 					<strong>Teilnehmer:</strong> {competition.participations.length}
 				</p>
 			</div>
-			<button className="button button--secondary" onClick={() => window.open(`/public-leaderboard/${id}`, '_blank')}>
-				Live Rangliste
-			</button>
+                        <Button variant="secondary" onClick={() => window.open(`/public-leaderboard/${id}`, '_blank')}>
+                                Live Rangliste
+                        </Button>
 			<ParticipantList participants={nextParticipants} title="Nächste Teilnehmer" />
 			<ParticipantList participants={completedParticipants} title="Abgeschlossene Teilnehmer" />
-			<button className="button" onClick={() => navigate(`/participantsList/${id}`)}>
-				Teilnehmer verwalten
-			</button>
+                        <Button onClick={() => navigate(`/participantsList/${id}`)}>
+                                Teilnehmer verwalten
+                        </Button>
 			<div className="competition-actions">
-				<button className="button button--secondary" onClick={() => navigate(`/`)}>
-					Zurück
-				</button>
-				<button className="button button--secondary delete-button" onClick={handleDeleteCompetition}>
-					Wettbewerb löschen
-				</button>
+                                <Button variant="secondary" onClick={() => navigate(`/`)}>
+                                        Zurück
+                                </Button>
+                                <Button variant="secondary" onClick={handleDeleteCompetition}>
+                                        Wettbewerb löschen
+                                </Button>
 			</div>
 		</main>
 	);

--- a/schiessmeister-client/src/pages/CreateCompetition.jsx
+++ b/schiessmeister-client/src/pages/CreateCompetition.jsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { createApi } from '../utils/api';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 
 const CreateCompetition = () => {
 	const navigate = useNavigate();
@@ -35,22 +37,20 @@ const CreateCompetition = () => {
 	return (
 		<main>
 			<h2>Wettbewerb erstellen</h2>
-			<form onSubmit={handleSubmit}>
-				<input type="text" placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} required />
+                        <form onSubmit={handleSubmit}>
+                                <Input type="text" placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} required />
 
-				<input type="text" placeholder="Standort" value={location} onChange={(e) => setLocation(e.target.value)} required />
+                                <Input type="text" placeholder="Standort" value={location} onChange={(e) => setLocation(e.target.value)} required />
 
-				<div>Datum</div>
-				<input type="datetime-local" value={date} onChange={(e) => setDate(e.target.value)} required />
+                                <div>Datum</div>
+                                <Input type="datetime-local" value={date} onChange={(e) => setDate(e.target.value)} required />
 
-				<button className="button" type="submit">
-					Speichern
-				</button>
+                                <Button type="submit">Speichern</Button>
 
-				<button type="button" className="button button--secondary" onClick={handleReset}>
-					Abbrechen
-				</button>
-			</form>
+                                <Button type="button" variant="secondary" onClick={handleReset}>
+                                        Abbrechen
+                                </Button>
+                        </form>
 		</main>
 	);
 };

--- a/schiessmeister-client/src/pages/Home.jsx
+++ b/schiessmeister-client/src/pages/Home.jsx
@@ -48,28 +48,28 @@ const Home = () => {
 			<h2>Wettbewerb öffnen</h2>
 
 			<div className="comp-list">
-				{competitions.map((comp) => (
-					<button className="button" key={comp.id} onClick={() => handleCompetitionClick(comp.id)}>
-						{comp.name}
-					</button>
-				))}
+                                {competitions.map((comp) => (
+                                        <Button key={comp.id} onClick={() => handleCompetitionClick(comp.id)}>
+                                                {comp.name}
+                                        </Button>
+                                ))}
 
 				{competitions.length == 0 && <p>Noch keine Bewerbe.</p>}
 			</div>
 			
 			<h2>Wettbewerb erstellen</h2>
 
-			<Link to="/createcompetition">
-				<button className="button">Erstellen</button>
-			</Link>
+                        <Link to="/createcompetition">
+                                <Button>Erstellen</Button>
+                        </Link>
 
 			<div className="account-actions">
-				<button className="button button--secondary logout-button" onClick={auth.logout}>
-					Abmelden
-				</button>
-				<button className="button button--secondary delete-button" onClick={handleDeleteAccount}>
-					Konto löschen
-				</button>
+                                <Button variant="secondary" onClick={auth.logout}>
+                                        Abmelden
+                                </Button>
+                                <Button variant="secondary" onClick={handleDeleteAccount}>
+                                        Konto löschen
+                                </Button>
 			</div>
 		</main>
 	);

--- a/schiessmeister-client/src/pages/Login.jsx
+++ b/schiessmeister-client/src/pages/Login.jsx
@@ -2,6 +2,9 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { loginRequest } from '../api/authService';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 
 const Login = () => {
 	const [username, setUsername] = useState('');
@@ -26,23 +29,21 @@ const Login = () => {
 		<main>
 			<h2>Melde dich an</h2>
 
-			<form onSubmit={handleSubmit}>
-				<div>
-					<label htmlFor="username">Username</label>
-					<input id="username" name="username" type="text" required placeholder="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
-				</div>
+                        <form onSubmit={handleSubmit}>
+                                <div>
+                                        <Label htmlFor="username">Username</Label>
+                                        <Input id="username" name="username" type="text" required placeholder="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
+                                </div>
 
-				<div>
-					<label htmlFor="password">Passwort</label>
-					<input id="password" name="password" type="password" required placeholder="Passwort" value={password} onChange={(e) => setPassword(e.target.value)} />
-				</div>
+                                <div>
+                                        <Label htmlFor="password">Passwort</Label>
+                                        <Input id="password" name="password" type="password" required placeholder="Passwort" value={password} onChange={(e) => setPassword(e.target.value)} />
+                                </div>
 
-				{error && <div>{error}</div>}
+                                {error && <div>{error}</div>}
 
-				<button className="button" type="submit">
-					Anmelden
-				</button>
-			</form>
+                                <Button type="submit">Anmelden</Button>
+                        </form>
 
 			<Link to="/register">Sie haben keinen Account? Registrieren</Link>
 		</main>

--- a/schiessmeister-client/src/pages/Participantslist.jsx
+++ b/schiessmeister-client/src/pages/Participantslist.jsx
@@ -3,6 +3,8 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { getCompetition, getShooters, createShooter, updateCompetition } from '../api/apiClient';
 import '../styles/Participantslist.css';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 
 const ParticipantsList = () => {
 	const { id } = useParams();
@@ -145,19 +147,19 @@ const ParticipantsList = () => {
 						<div className="controls">
 							<ul>
 								<li>
-									<button className="button button--tertiary" onClick={() => handleMoveParticipant(participation.id, 'up')} disabled={participation.orderNb === 1}>
-										Nach oben
-									</button>
+                                                                        <Button variant="outline" onClick={() => handleMoveParticipant(participation.id, 'up')} disabled={participation.orderNb === 1}>
+                                                                               Nach oben
+                                                                        </Button>
 								</li>
 								<li>
-									<button className="button button--tertiary" onClick={() => handleMoveParticipant(participation.id, 'down')} disabled={participation.orderNb === getMaxOrderNb()}>
-										Nach unten
-									</button>
+                                                                        <Button variant="outline" onClick={() => handleMoveParticipant(participation.id, 'down')} disabled={participation.orderNb === getMaxOrderNb()}>
+                                                                               Nach unten
+                                                                        </Button>
 								</li>
 								<li>
-									<button className="button button--tertiary" onClick={() => handleRemoveParticipant(participation.id)}>
-										Löschen
-									</button>
+                                                                        <Button variant="outline" onClick={() => handleRemoveParticipant(participation.id)}>
+                                                                               Löschen
+                                                                        </Button>
 								</li>
 							</ul>
 						</div>
@@ -172,11 +174,11 @@ const ParticipantsList = () => {
 			<div className="participant-list">
 				<h3>Schützen</h3>
 
-				{availableShooters.map((shooter) => (
-					<button key={shooter.id} className="button participant-button" onClick={() => handleAddParticipant(shooter.id)}>
-						{shooter.name}
-					</button>
-				))}
+                                {availableShooters.map((shooter) => (
+                                        <Button key={shooter.id} className="participant-button" onClick={() => handleAddParticipant(shooter.id)}>
+                                                {shooter.name}
+                                        </Button>
+                                ))}
 			</div>
 
 			<hr />
@@ -184,15 +186,15 @@ const ParticipantsList = () => {
 			<div className="actions">
 				<h3>Neuer Schütze</h3>
 
-				<input type="text" placeholder="Neuer Teilnehmer" value={newShooterName} onChange={(e) => setNewShooterName(e.target.value)} />
+                                <Input type="text" placeholder="Neuer Teilnehmer" value={newShooterName} onChange={(e) => setNewShooterName(e.target.value)} />
 
 				<div className="buttons">
-					<button className="button button--tertiary add-shooter-btn" onClick={handleCreateShooter}>
-						+ Teilnehmer erstellen
-					</button>
-					<button className="button back-btn" onClick={() => navigate(`/competition/${id}`)}>
-						Zurück
-					</button>
+                                        <Button variant="outline" className="add-shooter-btn" onClick={handleCreateShooter}>
+                                                + Teilnehmer erstellen
+                                        </Button>
+                                        <Button className="back-btn" onClick={() => navigate(`/competition/${id}`)}>
+                                                Zurück
+                                        </Button>
 				</div>
 			</div>
 		</main>

--- a/schiessmeister-client/src/pages/Register.jsx
+++ b/schiessmeister-client/src/pages/Register.jsx
@@ -2,6 +2,9 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { registerRequest, loginRequest } from '../api/authService';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 
 const Register = () => {
 	const [username, setUsername] = useState('');
@@ -28,28 +31,26 @@ const Register = () => {
 		<main>
 			<h2>Account erstellen</h2>
 
-			<form onSubmit={handleSubmit}>
-				<div>
-					<label htmlFor="username">Username</label>
-					<input id="username" name="username" type="text" required placeholder="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
-				</div>
+                        <form onSubmit={handleSubmit}>
+                                <div>
+                                        <Label htmlFor="username">Username</Label>
+                                        <Input id="username" name="username" type="text" required placeholder="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
+                                </div>
 
-				<div>
-					<label htmlFor="email">Email</label>
-					<input id="email" name="email" type="email" required placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
-				</div>
+                                <div>
+                                        <Label htmlFor="email">Email</Label>
+                                        <Input id="email" name="email" type="email" required placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+                                </div>
 
-				<div>
-					<label htmlFor="password">Passwort</label>
-					<input id="password" name="password" type="password" required placeholder="Passwort" value={password} onChange={(e) => setPassword(e.target.value)} />
-				</div>
+                                <div>
+                                        <Label htmlFor="password">Passwort</Label>
+                                        <Input id="password" name="password" type="password" required placeholder="Passwort" value={password} onChange={(e) => setPassword(e.target.value)} />
+                                </div>
 
-				{error && <div>{error}</div>}
+                                {error && <div>{error}</div>}
 
-				<button className="button" type="submit">
-					Registrieren
-				</button>
-			</form>
+                                <Button type="submit">Registrieren</Button>
+                        </form>
 
 			<Link to="/login">Sie haben schon einen Account? Anmelden</Link>
 		</main>

--- a/schiessmeister-client/src/pages/ResultsInput.jsx
+++ b/schiessmeister-client/src/pages/ResultsInput.jsx
@@ -4,6 +4,10 @@ import { getCompetition, updateCompetition } from '../api/apiClient';
 import { useAuth } from '../context/AuthContext';
 import { SHOOTING_CLASSES } from '../constants/shootingClasses';
 import '../styles/ResultsInput.css';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
 
 const ResultsInput = () => {
 	const { competitionId, participationId } = useParams();
@@ -90,39 +94,39 @@ const ResultsInput = () => {
 
 			<div className="number-pad">
 				<div className="number-grid">
-					{[1, 2, 3, 4, 5, 6, 7, 8, 9, 0].map((num) => (
-						<button key={num} className="number-button" onClick={() => handleNumberClick(num)} disabled={isMaxResults}>
-							{num}
-						</button>
-					))}
-					<button className="number-button number-button--large" onClick={() => handleNumberClick(10)} disabled={isMaxResults}>
-						10
-					</button>
-				</div>
-				<button className="button button--danger" onClick={handleRemoveLast} disabled={results.length === 0}>
-					Letzte Zahl löschen
-				</button>
+                                        {[1, 2, 3, 4, 5, 6, 7, 8, 9, 0].map((num) => (
+                                                <Button key={num} className="number-button" onClick={() => handleNumberClick(num)} disabled={isMaxResults} variant="outline">
+                                                        {num}
+                                                </Button>
+                                        ))}
+                                        <Button className="number-button number-button--large" onClick={() => handleNumberClick(10)} disabled={isMaxResults} variant="outline">
+                                                10
+                                        </Button>
+                                </div>
+                                <Button variant="destructive" onClick={handleRemoveLast} disabled={results.length === 0}>
+                                        Letzte Zahl löschen
+                                </Button>
 
 				<div className="shooting-class-select">
-					<label htmlFor="shootingClass">Schützenklasse:</label>
-					<select id="shootingClass" value={shootingClass} onChange={(e) => setShootingClass(e.target.value)}>
-						{SHOOTING_CLASSES.map(({ key, value }) => (
-							<option key={key} value={key}>
-								{value}
-							</option>
-						))}
-					</select>
-				</div>
-			</div>
+                                        <Label htmlFor="shootingClass">Schützenklasse:</Label>
+                                        <Select id="shootingClass" value={shootingClass} onChange={(e) => setShootingClass(e.target.value)}>
+                                                {SHOOTING_CLASSES.map(({ key, value }) => (
+                                                        <option key={key} value={key}>
+                                                                {value}
+                                                        </option>
+                                                ))}
+                                        </Select>
+                                </div>
+                        </div>
 
-			<div className="action-buttons">
-				<button className="button button--secondary reset-btn" onClick={() => navigate(`/competition/${competitionId}`)}>
-					Abbrechen
-				</button>
-				<button className="button" onClick={handleSave}>
-					Speichern
-				</button>
-			</div>
+                        <div className="action-buttons">
+                                <Button variant="secondary" className="reset-btn" onClick={() => navigate(`/competition/${competitionId}`)}>
+                                        Abbrechen
+                                </Button>
+                                <Button onClick={handleSave}>
+                                        Speichern
+                                </Button>
+                        </div>
 		</main>
 	);
 };


### PR DESCRIPTION
## Summary
- add Input, Label and Select components from shadcn
- refactor pages to replace plain HTML elements with shadcn components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: dependencies missing)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848634845408322a35686603b659104