### PR TITLE
Add writer section and role-based routing

### DIFF
--- a/schiessmeister-client/src/App.jsx
+++ b/schiessmeister-client/src/App.jsx
@@ -5,10 +5,14 @@ import CreateCompetition from './pages/CreateCompetition';
 import EditCompetition from './pages/EditCompetition';
 import CompetitionDetail from './pages/CompetitionDetail';
 import Results from './pages/Results';
+import ResultsInput from './pages/ResultsInput';
+import CompetitionOverview from './pages/CompetitionOverview';
+import ParticipantsList from './pages/Participantslist';
 import CreateParticipantGroup from './pages/CreateParticipantGroup';
 import EditParticipantGroup from './pages/EditParticipantGroup';
 import Logout from './pages/Logout';
 import CompetitionLeaderboard from './pages/CompetitionLeaderboard';
+import PublicLeaderboard from './pages/PublicLeaderboard';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import './App.css';
 import { StrictMode } from 'react';
@@ -29,22 +33,29 @@ export default function App() {
                                                 <Route path="login" element={<Login />} />
                                                 <Route path="register" element={<Register />} />
                                                 <Route path="logout" element={<Logout />} />
+                                                <Route path="public-leaderboard/:id" element={<PublicLeaderboard />} />
 
                                                 {/* Protected routes */}
                                                 <Route element={<ProtectedRoute />}>
-                                                        <Route path="competitions" element={<Competitions />} />
-                                                        <Route path="competitions/new" element={<CreateCompetition />} />
-                                                        <Route path="competitions/:id" element={<CompetitionDetail />} />
-                                                        <Route path="competitions/:id/edit" element={<EditCompetition />} />
-                                                        <Route path="results" element={<Results />} />
-                                                        <Route path="participant-groups/new" element={<CreateParticipantGroup />} />
-                                                        <Route path="participant-groups/:id/edit" element={<EditParticipantGroup />} />
-                                                        <Route path="competitions/:id/leaderboard" element={<CompetitionLeaderboard />} />
+                                                        {/* Manager */}
+                                                        <Route path="manager/competitions" element={<Competitions />} />
+                                                        <Route path="manager/competitions/new" element={<CreateCompetition />} />
+                                                        <Route path="manager/competitions/:id" element={<CompetitionDetail editable={false} />} />
+                                                        <Route path="manager/competitions/:id/edit" element={<EditCompetition />} />
+                                                        <Route path="manager/competitions/:id/leaderboard" element={<CompetitionLeaderboard />} />
+                                                        <Route path="manager/participant-groups/new" element={<CreateParticipantGroup />} />
+                                                        <Route path="manager/participant-groups/:id/edit" element={<EditParticipantGroup />} />
+
+                                                        {/* Writer */}
+                                                        <Route path="writer/competitions" element={<CompetitionOverview />} />
+                                                        <Route path="writer/competitions/:id" element={<CompetitionOverview />} />
+                                                        <Route path="writer/results/:competitionId/:participationId" element={<ResultsInput />} />
+                                                        <Route path="writer/participantsList/:id" element={<ParticipantsList />} />
                                                 </Route>
 
                                                 {/* Redirects */}
-                                                <Route path="/" element={<Navigate to="/competitions" replace />} />
-                                                <Route path="*" element={<Navigate to="/competitions" replace />} />
+                                                <Route path="/" element={<Navigate to="/login" replace />} />
+                                                <Route path="*" element={<Navigate to="/login" replace />} />
                                         </Routes>
                                 </DataProvider>
                         </AuthProvider>

--- a/schiessmeister-client/src/context/AuthContext.jsx
+++ b/schiessmeister-client/src/context/AuthContext.jsx
@@ -4,8 +4,9 @@ import { useNavigate } from 'react-router-dom';
 const AuthContext = createContext(null);
 
 export const AuthProvider = ({ children }) => {
-	const [token, setToken] = useState(localStorage.getItem('token'));
-	const [userId, setUserId] = useState(localStorage.getItem('userId'));
+        const [token, setToken] = useState(localStorage.getItem('token'));
+        const [userId, setUserId] = useState(localStorage.getItem('userId'));
+        const [role, setRole] = useState(localStorage.getItem('role'));
 	const navigate = useNavigate();
 
 	useEffect(() => {
@@ -16,31 +17,41 @@ export const AuthProvider = ({ children }) => {
 		}
 	}, [token]);
 
-	useEffect(() => {
-		if (userId) {
-			localStorage.setItem('userId', userId);
-		} else {
-			localStorage.removeItem('userId');
-		}
-	}, [userId]);
+        useEffect(() => {
+                if (userId) {
+                        localStorage.setItem('userId', userId);
+                } else {
+                        localStorage.removeItem('userId');
+                }
+        }, [userId]);
 
-	const login = (newToken, newUserId) => {
-		setToken(newToken);
-		setUserId(newUserId);
-		navigate('/home');
-	};
+        useEffect(() => {
+                if (role) {
+                        localStorage.setItem('role', role);
+                } else {
+                        localStorage.removeItem('role');
+                }
+        }, [role]);
 
-	const logout = () => {
-		setToken(null);
-		setUserId(null);
-		navigate('/login');
-	};
+        const login = (newToken, newUserId, newRole) => {
+                setToken(newToken);
+                setUserId(newUserId);
+                setRole(newRole);
+                navigate(`/${newRole}/competitions`);
+        };
+
+        const logout = () => {
+                setToken(null);
+                setUserId(null);
+                setRole(null);
+                navigate('/login');
+        };
 
 	const handleUnauthorized = () => {
 		logout();
 	};
 
-	return <AuthContext.Provider value={{ token, userId, login, logout, handleUnauthorized }}>{children}</AuthContext.Provider>;
+        return <AuthContext.Provider value={{ token, userId, role, login, logout, handleUnauthorized }}>{children}</AuthContext.Provider>;
 };
 
 export const useAuth = () => {

--- a/schiessmeister-client/src/pages/CompetitionDetail.jsx
+++ b/schiessmeister-client/src/pages/CompetitionDetail.jsx
@@ -79,7 +79,7 @@ function flattenGroups(groups, prefix = '') {
   }, []);
 }
 
-const CompetitionDetail = () => {
+const CompetitionDetail = ({ editable = true }) => {
   const { id } = useParams();
   const { competitions } = useData();
   const competition = competitions.find((c) => c.id === parseInt(id));
@@ -120,13 +120,15 @@ const CompetitionDetail = () => {
 
   if (!competition) return <div>Wettbewerb nicht gefunden</div>;
 
+  const basePath = '/manager';
+
   return (
     <main className="min-h-screen w-full px-4 py-10 bg-background">
       <div className="max-w-7xl mx-auto">
         <div className="flex items-center justify-between mb-8 border-b pb-2">
           <h2 className="text-3xl font-bold">{competition.name}</h2>
           <Button asChild variant="outline" className="ml-4">
-            <Link to={`/competitions/${id}/leaderboard`}>Leaderboard öffnen</Link>
+            <Link to={`${basePath}/competitions/${id}/leaderboard`}>Leaderboard öffnen</Link>
           </Button>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 items-start">
@@ -151,14 +153,15 @@ const CompetitionDetail = () => {
           </div>
           <div className="col-span-1 flex flex-col items-center">
             <label className="block font-medium mb-2">Teilnehmergruppen</label>
-            <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-              <DialogTrigger asChild>
-                <Button className="mb-4 w-full" variant="outline">Gruppe hinzufügen</Button>
-              </DialogTrigger>
-              <DialogContent>
-                <DialogHeader>
-                  <DialogTitle>Neue Teilnehmergruppe</DialogTitle>
-                </DialogHeader>
+            {editable && (
+              <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+                <DialogTrigger asChild>
+                  <Button className="mb-4 w-full" variant="outline">Gruppe hinzufügen</Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Neue Teilnehmergruppe</DialogTitle>
+                  </DialogHeader>
                 <Input
                   placeholder="Gruppenname"
                   value={newGroupName}
@@ -182,8 +185,9 @@ const CompetitionDetail = () => {
                     <Button variant="secondary">Abbrechen</Button>
                   </DialogClose>
                 </DialogFooter>
-              </DialogContent>
-            </Dialog>
+                </DialogContent>
+              </Dialog>
+            )}
             <div className="w-full mt-4 bg-white border rounded-lg p-2 shadow-sm min-h-[80px]">
               <TreeView data={mapGroupsToTree(groups)} />
             </div>
@@ -191,11 +195,13 @@ const CompetitionDetail = () => {
         </div>
         <div className="flex justify-between mt-16">
           <Button asChild variant="outline">
-            <Link to="/competitions">Zurück</Link>
+            <Link to={`${basePath}/competitions`}>Zurück</Link>
           </Button>
-          <Button asChild variant="outline">
-            <Link to={`/competitions/${id}/edit`}>Bearbeiten</Link>
-          </Button>
+          {editable && (
+            <Button asChild variant="outline">
+              <Link to={`${basePath}/competitions/${id}/edit`}>Bearbeiten</Link>
+            </Button>
+          )}
         </div>
       </div>
     </main>

--- a/schiessmeister-client/src/pages/CompetitionLeaderboard.jsx
+++ b/schiessmeister-client/src/pages/CompetitionLeaderboard.jsx
@@ -40,7 +40,7 @@ const CompetitionLeaderboard = () => {
     <main className="min-h-screen w-full px-4 py-10 bg-background">
       <div className="mb-6">
         <Button asChild variant="outline">
-          <Link to={`/competitions/${id}`}>Zurück</Link>
+          <Link to={`/manager/competitions/${id}`}>Zurück</Link>
         </Button>
       </div>
       <h2 className="text-3xl font-bold mb-8">Rangliste - {competition.name}</h2>

--- a/schiessmeister-client/src/pages/CompetitionOverview.jsx
+++ b/schiessmeister-client/src/pages/CompetitionOverview.jsx
@@ -10,7 +10,8 @@ const CompetitionOverview = () => {
 	const navigate = useNavigate();
 	const [competition, setCompetition] = useState(null);
 	const [error, setError] = useState(null);
-	const auth = useAuth();
+        const auth = useAuth();
+        const basePath = auth.role === 'manager' ? '/manager' : '/writer';
 
 	const parseResults = (participation) => {
 		let results = JSON.parse(participation.results || '[]');
@@ -62,7 +63,7 @@ const CompetitionOverview = () => {
 				{participants.map((participation) => (
 					<div key={participation.id} className="participant-item">
 						<span className="participant-name">{participation.shooter.name}</span>
-                                                <Button variant="outline" onClick={() => navigate(`/results/${id}/${participation.id}`)}>
+                                                <Button variant="outline" onClick={() => navigate(`${basePath}/results/${id}/${participation.id}`)}>
                                                         Ergebnisse
                                                 </Button>
 					</div>
@@ -89,19 +90,23 @@ const CompetitionOverview = () => {
                         <Button variant="secondary" onClick={() => window.open(`/public-leaderboard/${id}`, '_blank')}>
                                 Live Rangliste
                         </Button>
-			<ParticipantList participants={nextParticipants} title="Nächste Teilnehmer" />
-			<ParticipantList participants={completedParticipants} title="Abgeschlossene Teilnehmer" />
-                        <Button onClick={() => navigate(`/participantsList/${id}`)}>
-                                Teilnehmer verwalten
-                        </Button>
-			<div className="competition-actions">
-                                <Button variant="secondary" onClick={() => navigate(`/`)}>
+                        <ParticipantList participants={nextParticipants} title="Nächste Teilnehmer" />
+                        <ParticipantList participants={completedParticipants} title="Abgeschlossene Teilnehmer" />
+                        {auth.role === 'manager' && (
+                                <Button onClick={() => navigate(`${basePath}/participantsList/${id}`)}>
+                                        Teilnehmer verwalten
+                                </Button>
+                        )}
+                        <div className="competition-actions">
+                                <Button variant="secondary" onClick={() => navigate(`${basePath}/competitions`)}>
                                         Zurück
                                 </Button>
-                                <Button variant="secondary" onClick={handleDeleteCompetition}>
-                                        Wettbewerb löschen
-                                </Button>
-			</div>
+                                {auth.role === 'manager' && (
+                                        <Button variant="secondary" onClick={handleDeleteCompetition}>
+                                                Wettbewerb löschen
+                                        </Button>
+                                )}
+                        </div>
 		</main>
 	);
 };

--- a/schiessmeister-client/src/pages/Competitions.jsx
+++ b/schiessmeister-client/src/pages/Competitions.jsx
@@ -1,20 +1,25 @@
 import { Link } from 'react-router-dom';
 import { useData } from '../context/DataContext';
+import { useAuth } from '../context/AuthContext';
 import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { CalendarDays } from 'lucide-react';
 
 const Competitions = () => {
   const { competitions } = useData();
+  const { role } = useAuth();
+  const basePath = role === 'manager' ? '/manager' : '/writer';
 
   return (
     <main className="min-h-screen w-full px-4 py-10 bg-background">
       <div className="max-w-5xl mx-auto">
         <div className="flex items-center justify-between mb-8">
           <h2 className="text-2xl font-bold">Meine Wettbewerbe</h2>
-          <Link to="/competitions/new">
-            <Button variant="default">Neuer Wettbewerb</Button>
-          </Link>
+          {role === 'manager' && (
+            <Link to={`${basePath}/competitions/new`}>
+              <Button variant="default">Neuer Wettbewerb</Button>
+            </Link>
+          )}
         </div>
         <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
           {competitions.map((c) => (
@@ -29,7 +34,7 @@ const Competitions = () => {
                 </div>
                 <span className="bg-black text-white text-xs rounded px-2 py-0.5 w-fit">{c.participants} Teilnehmer</span>
                 <div className="flex justify-end w-full mt-2">
-                  <Link to={`/competitions/${c.id}`}>
+                  <Link to={`${basePath}/competitions/${c.id}`}>
                     <Button className="bg-black text-white hover:bg-black/80">Öffnen</Button>
                   </Link>
                 </div>

--- a/schiessmeister-client/src/pages/CreateCompetition.jsx
+++ b/schiessmeister-client/src/pages/CreateCompetition.jsx
@@ -8,7 +8,7 @@ const CreateCompetition = () => {
 
   const handleSubmit = (data) => {
     addCompetition(data);
-    navigate('/competitions');
+    navigate('/manager/competitions');
   };
 
   return (
@@ -17,7 +17,7 @@ const CreateCompetition = () => {
         initialValues={{}}
         onSubmit={handleSubmit}
         submitLabel="Erstellen"
-        onCancel={() => navigate('/competitions')}
+        onCancel={() => navigate('/manager/competitions')}
       />
     </main>
   );

--- a/schiessmeister-client/src/pages/EditCompetition.jsx
+++ b/schiessmeister-client/src/pages/EditCompetition.jsx
@@ -12,7 +12,7 @@ const EditCompetition = () => {
 
   const handleSubmit = (data) => {
     updateCompetition(competition.id, data);
-    navigate(`/competitions/${competition.id}`);
+    navigate(`/manager/competitions/${competition.id}`);
   };
 
   return (
@@ -21,7 +21,7 @@ const EditCompetition = () => {
         initialValues={competition}
         onSubmit={handleSubmit}
         submitLabel="Speichern"
-        onCancel={() => navigate(`/competitions/${competition.id}`)}
+        onCancel={() => navigate(`/manager/competitions/${competition.id}`)}
       />
     </main>
   );

--- a/schiessmeister-client/src/pages/EditParticipantGroup.jsx
+++ b/schiessmeister-client/src/pages/EditParticipantGroup.jsx
@@ -98,7 +98,7 @@ const EditParticipantGroup = () => {
   return (
     <main className="max-w-3xl mx-auto mt-8 bg-white rounded-xl border p-8 shadow">
       <div className="mb-6 text-sm text-muted-foreground flex gap-2 items-center">
-        <Link to={`/competitions/${competition.id}`} className="hover:underline text-black">{competition.name}</Link>
+        <Link to={`/manager/competitions/${competition.id}`} className="hover:underline text-black">{competition.name}</Link>
         <span>/</span>
         <span className="text-black font-medium">{group.title || title}</span>
       </div>

--- a/schiessmeister-client/src/pages/Home.jsx
+++ b/schiessmeister-client/src/pages/Home.jsx
@@ -25,9 +25,9 @@ const Home = () => {
 		fetchCompetitions();
 	}, [auth]);
 
-	const handleCompetitionClick = (id) => {
-		navigate(`/competition/${id}`);
-	};
+        const handleCompetitionClick = (id) => {
+                navigate(`/manager/competitions/${id}`);
+        };
 
 	const handleDeleteAccount = async () => {
 		if (window.confirm('Möchten Sie Ihr Konto wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.')) {

--- a/schiessmeister-client/src/pages/Login.jsx
+++ b/schiessmeister-client/src/pages/Login.jsx
@@ -10,16 +10,17 @@ import { Link } from 'react-router-dom';
 const Login = () => {
 	const [email, setEmail] = useState('');
 	const [password, setPassword] = useState('');
-	const [error, setError] = useState('');
-	const { login } = useAuth();
+        const [error, setError] = useState('');
+        const [role, setRole] = useState('manager');
+        const { login } = useAuth();
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
 		setError('');
 
 		try {
-			const data = await loginRequest(email, password);
-			login(data.token, data.id);
+                        const data = await loginRequest(email, password);
+                        login(data.token, data.id, role);
 		} catch (error) {
 			setError('Invalid email or password');
 			console.error('Login error:', error);
@@ -47,20 +48,32 @@ const Login = () => {
 								autoComplete="email"
 							/>
 						</div>
-						<div>
-							<Input
-								id="password"
-								name="password"
-								type="password"
-								required
-								placeholder="Passwort"
-								value={password}
-								onChange={(e) => setPassword(e.target.value)}
-								autoComplete="current-password"
-							/>
-						</div>
-						{error && <div className="text-red-600 text-sm -mt-2">{error}</div>}
-						<Button type="submit" className="w-full mt-2">Login</Button>
+                                               <div>
+                                                       <Input
+                                                               id="password"
+                                                               name="password"
+                                                               type="password"
+                                                               required
+                                                               placeholder="Passwort"
+                                                               value={password}
+                                                               onChange={(e) => setPassword(e.target.value)}
+                                                               autoComplete="current-password"
+                                                       />
+                                               </div>
+                                               <div>
+                                                       <Label htmlFor="role">Bereich</Label>
+                                                       <select
+                                                               id="role"
+                                                               className="w-full border rounded-md px-3 py-2"
+                                                               value={role}
+                                                               onChange={(e) => setRole(e.target.value)}
+                                                       >
+                                                               <option value="manager">Manager</option>
+                                                               <option value="writer">Writer</option>
+                                                       </select>
+                                               </div>
+                                               {error && <div className="text-red-600 text-sm -mt-2">{error}</div>}
+                                               <Button type="submit" className="w-full mt-2">Login</Button>
 					</form>
 					<div className="mt-6 text-center">
 						<Link to="/register" className="text-sm text-muted-foreground hover:underline">Sie haben keinen Account? Registrieren</Link>

--- a/schiessmeister-client/src/pages/Participantslist.jsx
+++ b/schiessmeister-client/src/pages/Participantslist.jsx
@@ -192,7 +192,7 @@ const ParticipantsList = () => {
                                         <Button variant="outline" className="add-shooter-btn" onClick={handleCreateShooter}>
                                                 + Teilnehmer erstellen
                                         </Button>
-                                        <Button className="back-btn" onClick={() => navigate(`/competition/${id}`)}>
+                                        <Button className="back-btn" onClick={() => navigate(`/manager/competitions/${id}`)}>
                                                 Zurück
                                         </Button>
 				</div>

--- a/schiessmeister-client/src/pages/ResultsInput.jsx
+++ b/schiessmeister-client/src/pages/ResultsInput.jsx
@@ -66,8 +66,8 @@ const ResultsInput = () => {
 				...competition,
 				participations: updatedParticipations
 			};
-			await updateCompetition(competitionId, updatedCompetition, auth);
-			navigate(`/competition/${competitionId}`);
+                        await updateCompetition(competitionId, updatedCompetition, auth);
+                        navigate(`/writer/competitions/${competitionId}`);
 		} catch (err) {
 			setError('Failed to save results');
 			console.error(err);
@@ -120,7 +120,7 @@ const ResultsInput = () => {
                         </div>
 
                         <div className="action-buttons">
-                                <Button variant="secondary" className="reset-btn" onClick={() => navigate(`/competition/${competitionId}`)}>
+                                <Button variant="secondary" className="reset-btn" onClick={() => navigate(`/writer/competitions/${competitionId}`)}>
                                         Abbrechen
                                 </Button>
                                 <Button onClick={handleSave}>


### PR DESCRIPTION
## Summary
- extend auth context to store chosen role
- allow role selection on login
- prefix routes with `/manager` and `/writer`
- hide management actions from writers
- adjust navigation paths for new sections

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68489723bac08322a1387f76531e09e0